### PR TITLE
Using culture invariant versions of TpUpper and ToLower while geneart…

### DIFF
--- a/src/NSwag.CodeGeneration/OperationNameGenerators/MultipleClientsFromPathSegmentsOperationNameGenerator.cs
+++ b/src/NSwag.CodeGeneration/OperationNameGenerators/MultipleClientsFromPathSegmentsOperationNameGenerator.cs
@@ -80,8 +80,8 @@ namespace NSwag.CodeGeneration.OperationNameGenerators
                 return string.Empty;
             }
 
-            var capitalized = name.ToLower();
-            return char.ToUpper(capitalized[0]) + (capitalized.Length > 1 ? capitalized.Substring(1) : "");
+            var capitalized = name.ToLowerInvariant();
+            return char.ToUpperInvariant(capitalized[0]) + (capitalized.Length > 1 ? capitalized.Substring(1) : "");
         }
     }
 }

--- a/src/NSwag.CodeGeneration/OperationNameGenerators/SingleClientFromPathSegmentsOperationNameGenerator.cs
+++ b/src/NSwag.CodeGeneration/OperationNameGenerators/SingleClientFromPathSegmentsOperationNameGenerator.cs
@@ -81,8 +81,8 @@ namespace NSwag.CodeGeneration.OperationNameGenerators
                 return string.Empty;
             }
 
-            var capitalized = name.ToLower();
-            return char.ToUpper(capitalized[0]) + (capitalized.Length > 1 ? capitalized.Substring(1) : "");
+            var capitalized = name.ToLowerInvariant();
+            return char.ToUpperInvariant(capitalized[0]) + (capitalized.Length > 1 ? capitalized.Substring(1) : "");
         }
     }
 }


### PR DESCRIPTION
…ing operation names (#2594)

eg: If  regional settings format is Turkish, the classical 'i' character problem occurs.